### PR TITLE
Fix controller declarations and operators

### DIFF
--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -93,8 +93,10 @@ udev_device* Controller::get_udev_device() const { return m_udev_device; }
 
 void Controller::set_active(bool v) {
   if (m_is_active != v) {
-    log_debug("activation status: " << v << " "
-                                    << m_activation_cb.target<void*>());
+    std::ostringstream oss;
+    oss << "activation status: " << v << " "
+    << m_activation_cb.target<void*>();
+    log_debug(oss.str());
     m_is_active = v;
     if (m_activation_cb) {
       m_activation_cb();

--- a/src/controller.hpp
+++ b/src/controller.hpp
@@ -23,6 +23,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <vector>
 
 extern "C" {
 #include <libudev.h>
@@ -50,6 +51,8 @@ class Controller {
 
  public:
   Controller();
+  const std::vector<uint16_t>& get_ff_features() const { return m_ff_features; }
+  int get_num_ff_effects() const { return m_num_ff_effects; }
   virtual ~Controller();
 
   void set_rumble(uint8_t left, uint8_t right);


### PR DESCRIPTION
in controller.cpp there is a problem using the << operator in log_debug. generating the error: no type named 'type' in 'struct std::enable_if<false, void>', the operator<< is causing a substitution failure.

in controller.hpp there is also a problem in the declaration of the get_ff_features() function of the Controller class in the controller.hpp file, generating the error: 
no match for 'operator<<' (operand types are 'std::basic_ostream<char>' and 'boost::function<void()>').

There is also the error: 'vector' in namespace 'std' does not name a template type, where the compiler does not recognize the std::vector type because you did not include the <vector> header in the file where std::vector is used.

problems were found using gcc-c++ version 13