### PR TITLE
add missing include

### DIFF
--- a/src/helper.hpp
+++ b/src/helper.hpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <sys/types.h>
 #include <vector>
 
 int hexstr2int(const std::string& str);


### PR DESCRIPTION
The pid_t type is defined in sys/types.h, which might not be indirectly included in some libc implementations, e.g. musl libc. The issue is addressed by explicitly including the missing system header file.

Downstream-issue: https://bugs.gentoo.org/936526