### PR TITLE
build(meson): install dbus configuration file in datadir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,7 @@ install_data(
 
 install_data(
   sources: 'data/org.seul.Xboxdrv.conf',
-  install_dir: get_option('sysconfdir') / 'dbus-1' / 'system.d'
+  install_dir: get_option('datadir') / 'dbus-1' / 'system.d'
 )
 
 install_data(


### PR DESCRIPTION
From dbus-daemon(1) man-page:

The standard system bus normally reads additional XML files from /usr/share/dbus-1/system.d. Third-party packages should install the default policies necessary for correct operation into that directory, which has been supported since dbus 1.10 (released in 2015).