### PR TITLE
fix: move references from /var/run to /run

### DIFF
--- a/data/xboxdrv.service
+++ b/data/xboxdrv.service
@@ -5,8 +5,8 @@ Documentation=man:xboxdrv(1)
 [Service]
 Type=forking
 User=root
-PIDFile=/var/run/xboxdrv.pid
-ExecStart=/usr/bin/xboxdrv --daemon --detach --pid-file /var/run/xboxdrv.pid -c /etc/default/xboxdrv --detach-kernel-driver --deadzone 4000 --deadzone-trigger 10%
+PIDFile=/run/xboxdrv.pid
+ExecStart=/usr/bin/xboxdrv --daemon --detach --pid-file /run/xboxdrv.pid -c /etc/default/xboxdrv --detach-kernel-driver --deadzone 4000 --deadzone-trigger 10%
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/xboxdrv.1
+++ b/doc/xboxdrv.1
@@ -1868,7 +1868,7 @@ via \*(T<\fB\-\-detach\fR\*(T>, to get a handle on it to kill
 it you can write its pid via the \*(T<\fB\-\-pid\-file\fR\*(T>:
 .PP
 .nf
-\*(T<$ sudo xboxdrv \-\-daemon \-\-detach \-\-pid\-file /var/run/xboxdrv.pid\*(T>
+\*(T<$ sudo xboxdrv \-\-daemon \-\-detach \-\-pid\-file /run/xboxdrv.pid\*(T>
 .fi
 .SH "XBOXDRV DAEMON DBUS INTERFACE"
 When Xboxdrv is run as daemon it will export some API functions

--- a/doc/xboxdrv.xml
+++ b/doc/xboxdrv.xml
@@ -2722,7 +2722,7 @@ $ modprobe joydev]]></programlisting>
         via <option>--detach</option>, to get a handle on it to kill
         it you can write its pid via the <option>--pid-file</option>:
       </para>
-      <programlisting>$ sudo xboxdrv --daemon --detach --pid-file /var/run/xboxdrv.pid</programlisting>
+      <programlisting>$ sudo xboxdrv --daemon --detach --pid-file /run/xboxdrv.pid</programlisting>
     </refsect2>
   </refsect1>
 

--- a/examples/default.xboxdrv
+++ b/examples/default.xboxdrv
@@ -71,7 +71,7 @@
 # detach = true
 # on-connect = /home/juser/bin/on-connect.sh
 # on-disconnect = /home/juser/bin/on-connect.sh
-# pid-file = /var/run/xboxdrv.pid
+# pid-file = /run/xboxdrv.pid
 
 [autofire]
 


### PR DESCRIPTION
systemd considers /var/run as a legacy directory and advises units to update to /var instead.

systemd[1]: xboxdrv.service:8: PIDFile= references a path below legacy directory /var/run/, updating /var/run/xboxdrv.pid → /run/xboxdrv.pid; please update the unit file accordingly.