### PR TITLE
Fix force feedback for USB controller backends

### DIFF
--- a/src/force_feedback_handler.cpp
+++ b/src/force_feedback_handler.cpp
@@ -272,37 +272,130 @@ int ForceFeedbackHandler::get_max_effects() {
   return max_effects;
 }
 
+namespace {
+// Only the evdev backend implements upload/erase/play/stop on the
+// controller side (and announces the device's capabilities via
+// get_ff_features()).  Every other backend (USB controllers) inherits
+// the no-op defaults from Controller, so fall back to the internal
+// effect engine and drive the rumble motors through set_rumble().
+bool controller_handles_ff(Controller *controller) {
+  return !controller->get_ff_features().empty();
+}
+}  // namespace
+
 void ForceFeedbackHandler::upload(const struct ff_effect &effect) {
   log_debug(
       "FF_UPLOAD(" << "effect_id:" << effect.id << ", effect_type:" << effect.type
                    << ",\n          " << effect << ")"
   );
-  m_controller->upload(effect);
+
+  if (controller_handles_ff(m_controller)) {
+    m_controller->upload(effect);
+    return;
+  }
+
+  Effects::iterator i = effects.find(effect.id);
+  if (i == effects.end()) {
+    effects[effect.id] = ForceFeedbackEffect(effect);
+  } else {
+    ForceFeedbackEffect old_effect = i->second;
+    ForceFeedbackEffect new_effect(effect);
+
+    // copy the state variables so the effect can be updated while playing
+    new_effect.playing = old_effect.playing;
+    new_effect.count = old_effect.count;
+    new_effect.weak_magnitude = old_effect.weak_magnitude;
+    new_effect.strong_magnitude = old_effect.strong_magnitude;
+
+    effects[effect.id] = new_effect;
+  }
 }
 
 void ForceFeedbackHandler::erase(int id) {
   log_debug("FF_ERASE(effect_id:" << id << ")");
-  m_controller->erase(id);
+
+  if (controller_handles_ff(m_controller)) {
+    m_controller->erase(id);
+    return;
+  }
+
+  Effects::iterator i = effects.find(id);
+  if (i != effects.end()) {
+    effects.erase(i);
+  } else {
+    log_warn("unknown id " << id);
+  }
 }
 
 void ForceFeedbackHandler::play(int id) {
   log_debug("FFPlay(effect_id:" << id << ")");
-  m_controller->play(id);
+
+  if (controller_handles_ff(m_controller)) {
+    m_controller->play(id);
+    return;
+  }
+
+  Effects::iterator i = effects.find(id);
+  if (i != effects.end()) {
+    i->second.play();
+  } else {
+    log_warn("unknown id " << id);
+  }
 }
 
 void ForceFeedbackHandler::stop(int id) {
   log_debug("FFStop(effect_id:" << id << ")");
-  m_controller->stop(id);
+
+  if (controller_handles_ff(m_controller)) {
+    m_controller->stop(id);
+    return;
+  }
+
+  Effects::iterator i = effects.find(id);
+  if (i != effects.end()) {
+    i->second.stop();
+  } else {
+    log_warn("unknown id " << id);
+  }
 }
 
-void ForceFeedbackHandler::set_gain(int gain) {
-  log_debug("FFGain(g:" << gain << ")");
-  m_controller->set_gain(gain);
+void ForceFeedbackHandler::set_gain(int g) {
+  log_debug("FFGain(g:" << g << ")");
+
+  if (controller_handles_ff(m_controller)) {
+    m_controller->set_gain(g);
+    return;
+  }
+
+  gain = g;
 }
 
 void ForceFeedbackHandler::update(int msec_delta) {
   weak_magnitude = 0;
   strong_magnitude = 0;
+
+  if (controller_handles_ff(m_controller)) {
+    return;
+  }
+
+  if (!effects.empty()) {
+    for (Effects::iterator i = effects.begin(); i != effects.end(); ++i) {
+      i->second.update(msec_delta);
+
+      weak_magnitude += i->second.get_weak_magnitude();
+      strong_magnitude += i->second.get_strong_magnitude();
+    }
+
+    weak_magnitude = std::min(weak_magnitude, 0x7fff);
+    strong_magnitude = std::min(strong_magnitude, 0x7fff);
+  }
+
+  // The uinput-side ff callback path is gone, so drive the rumble
+  // motors directly; set_rumble() ignores repeated identical values.
+  m_controller->set_rumble(
+      static_cast<unsigned char>(get_strong_magnitude() / 128),
+      static_cast<unsigned char>(get_weak_magnitude() / 128)
+  );
 }
 
 int ForceFeedbackHandler::get_weak_magnitude() const {

--- a/src/linux_uinput.cpp
+++ b/src/linux_uinput.cpp
@@ -219,6 +219,25 @@ void LinuxUinput::finish() {
     for (size_t i = 0; i < m_controller->get_ff_features().size(); ++i) {
       add_ff(m_controller->get_ff_features()[i]);
     }
+
+    // USB controller backends never fill in m_ff_features (only the
+    // evdev backend queries the device), which left the uinput device
+    // with EV_FF set but no effect types, so clients had nothing to
+    // upload. Fall back to the standard set the original upstream
+    // registered in controller_slot_config.cpp.
+    if (m_controller->get_ff_features().empty()) {
+      add_ff(FF_RUMBLE);
+      add_ff(FF_PERIODIC);
+      add_ff(FF_CONSTANT);
+      add_ff(FF_RAMP);
+      add_ff(FF_SINE);
+      add_ff(FF_TRIANGLE);
+      add_ff(FF_SQUARE);
+      add_ff(FF_SAW_UP);
+      add_ff(FF_SAW_DOWN);
+      add_ff(FF_CUSTOM);
+      add_ff(FF_GAIN);
+    }
   }
 
   strncpy(user_dev.name, name.c_str(), UINPUT_MAX_NAME_SIZE - 1);
@@ -232,6 +251,13 @@ void LinuxUinput::finish() {
 
   if (m_force_feedback_enabled) {
     user_dev.ff_effects_max = m_controller->get_num_ff_effects();
+
+    // USB controllers never fill in m_num_ff_effects (only the evdev
+    // backend queries EVIOCGEFFECTS), and the kernel refuses uinput
+    // devices that set FF_BIT with ff_effects_max == 0.
+    if (user_dev.ff_effects_max == 0) {
+      user_dev.ff_effects_max = 16;
+    }
   }
 
   {
@@ -305,22 +331,11 @@ void LinuxUinput::sync() {
 }
 
 void LinuxUinput::update(int msec_delta) {
-#if 0
-  if (ff_bit)
-  {
-    assert(m_ff_handler);
-
+  // Tick the effect engine so uploaded effects actually reach the
+  // rumble motors (the handler is a passthrough for evdev backends).
+  if (m_force_feedback_enabled && m_ff_handler) {
     m_ff_handler->update(msec_delta);
-
-    log_info(std::format("{:#5d} {:5d}", m_ff_handler->get_strong_magnitude() , m_ff_handler->get_weak_magnitude()));
-
-    if (m_ff_callback)
-    {
-      m_ff_callback(static_cast<unsigned char>(m_ff_handler->get_strong_magnitude() / 128),
-                    static_cast<unsigned char>(m_ff_handler->get_weak_magnitude()   / 128));
-    }
   }
-#endif
 }
 
 gboolean LinuxUinput::on_read_data(GIOChannel *source, GIOCondition condition) {


### PR DESCRIPTION
Fixes #11.

Force feedback only worked with the evdev backend. USB controllers hit three problems, all from the FF paths being evdev-only (full diagnosis in the issue):

1. `ff_effects_max` stayed 0 — only `EvdevController` queries `EVIOCGEFFECTS` — and the kernel rejects `UI_DEV_CREATE` with `EV_FF` set and `ff_effects_max == 0`, so the uinput device was never created (`LinuxUinput::finish(): unable to create uinput device: Invalid argument`).
2. No effect types were registered (`m_ff_features` is evdev-only), so even a created device advertised `EV_FF` with an empty effect list (`B: FF=0`) and clients had nothing to upload.
3. Uploaded effects were never executed: `upload/play/stop` delegate to `Controller` methods that are no-ops for non-evdev backends, and the internal effect engine tick was `#if 0`'d out, so `set_rumble()` was never called.

The fix keeps the evdev passthrough when the controller actually implements FF (non-empty `get_ff_features()`); otherwise it falls back to the pre-457916e internal effect engine: registers the standard effect set, defaults `ff_effects_max` to 16, and drives `set_rumble()` from the update tick (which already deduplicates repeated values).

Tested on real hardware (8BitDo Ultimate 2, `2dc8:310b`, `--device-by-id --type xbox360 --force-feedback --mimic-xpad`): device is created, `FF_RUMBLE` uploads play on the physical motors, and browser Gamepad API vibration works. `meson compile` is clean.

I understand xboxdrv is deprecated — this is meant as exactly the kind of small keep-it-usable fix mentioned in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)